### PR TITLE
Xbox 360 improvements, minor QoL improvements

### DIFF
--- a/DDS/DXEnums.cs
+++ b/DDS/DXEnums.cs
@@ -120,6 +120,7 @@
             P8 = 113,
             A8P8 = 114,
             B4G4R4A4UNORM = 115,
+            A4B4G4R4UNORM = 191,
             FORCEUINT = 0xffffffff
         }
     }

--- a/Swizzling/Xbox360Deswizzler.cs
+++ b/Swizzling/Xbox360Deswizzler.cs
@@ -34,16 +34,43 @@ namespace DrSwizzler.Swizzling
                     X360AlignX = 0;
                     X360AlignY = 0;
                     break;
+                case DXGIFormat.A8UNORM:
+                case DXGIFormat.R8TYPELESS:
+                case DXGIFormat.R8UNORM:
+                case DXGIFormat.R8SNORM:
+                case DXGIFormat.R8UINT:
+                case DXGIFormat.R8SINT:
+                    X360AlignX = 64;
+                    X360AlignY = 64;
+                    break;
+                case DXGIFormat.R8G8TYPELESS:
+                case DXGIFormat.R8G8UNORM:
+                case DXGIFormat.R8G8SNORM:
+                case DXGIFormat.R8G8UINT:
+                    X360AlignX = 64;
+                    X360AlignY = 32;
+                    break;
+                case DXGIFormat.R8G8B8A8TYPELESS:
                 case DXGIFormat.R8G8B8A8UNORM:
+                case DXGIFormat.R8G8B8A8UNORMSRGB:
+                case DXGIFormat.R8G8B8A8SNORM:
+                case DXGIFormat.R8G8B8A8UINT:
+                case DXGIFormat.R8G8B8A8SINT:
+                case DXGIFormat.B8G8R8A8TYPELESS:
                 case DXGIFormat.B8G8R8A8UNORM:
+                case DXGIFormat.B8G8R8A8UNORMSRGB:
                     X360AlignX = 32;
                     X360AlignY = 32;
                     break;
+                case DXGIFormat.BC1TYPELESS:
                 case DXGIFormat.BC1UNORM:
+                case DXGIFormat.BC1UNORMSRGB:
+                case DXGIFormat.BC2TYPELESS:
                 case DXGIFormat.BC2UNORM:
+                case DXGIFormat.BC2UNORMSRGB:
+                case DXGIFormat.BC3TYPELESS:
                 case DXGIFormat.BC3UNORM:
-                case DXGIFormat.BC4UNORM:
-                case DXGIFormat.BC5UNORM:
+                case DXGIFormat.BC3UNORMSRGB:
                     X360AlignX = 128;
                     X360AlignY = 128;
                     break;

--- a/Util.cs
+++ b/Util.cs
@@ -226,8 +226,6 @@ namespace DrSwizzler
               31
         };
 
-        
-
         /// <summary>
         /// Based on RawTex handling
         /// </summary>
@@ -253,7 +251,6 @@ namespace DrSwizzler
                 sourceBytesPerPixelSet = formatBpp * 2;
             }
         }
-
 
         /// <summary>
         /// RawTex Implementation

--- a/Util.cs
+++ b/Util.cs
@@ -6,127 +6,186 @@ namespace DrSwizzler
     public class Util
     {
         /// <summary>
-        /// RawTex Implementation
+        /// Based on DirectXTex
         /// </summary>
-        public static int[] bitsPerPixel = new int[116]
+        public static int BitsPerPixel(DXGIFormat pixelFormat)
         {
-              0,
-              128,
-              128,
-              128,
-              128,
-              96,
-              96,
-              96,
-              96,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              64,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              16,
-              8,
-              8,
-              8,
-              8,
-              8,
-              8,
-              1,
-              32,
-              32,
-              32,
-              4,
-              4,
-              4,
-              8,
-              8,
-              8,
-              8,
-              8,
-              8,
-              4,
-              4,
-              4,
-              8,
-              8,
-              8,
-              16,
-              16,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              32,
-              8,
-              8,
-              8,
-              8,
-              8,
-              8,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              16
-        };
+            switch (pixelFormat)
+            {
+                case DXGIFormat.R32G32B32A32TYPELESS:
+                case DXGIFormat.R32G32B32A32FLOAT:
+                case DXGIFormat.R32G32B32A32UINT:
+                case DXGIFormat.R32G32B32A32SINT:
+                    return 128;
+
+                case DXGIFormat.R32G32B32TYPELESS:
+                case DXGIFormat.R32G32B32FLOAT:
+                case DXGIFormat.R32G32B32UINT:
+                case DXGIFormat.R32G32B32SINT:
+                    return 96;
+
+                case DXGIFormat.R16G16B16A16TYPELESS:
+                case DXGIFormat.R16G16B16A16FLOAT:
+                case DXGIFormat.R16G16B16A16UNORM:
+                case DXGIFormat.R16G16B16A16UINT:
+                case DXGIFormat.R16G16B16A16SNORM:
+                case DXGIFormat.R16G16B16A16SINT:
+                case DXGIFormat.R32G32TYPELESS:
+                case DXGIFormat.R32G32FLOAT:
+                case DXGIFormat.R32G32UINT:
+                case DXGIFormat.R32G32SINT:
+                case DXGIFormat.R32G8X24TYPELESS:
+                case DXGIFormat.D32FLOATS8X24UINT:
+                case DXGIFormat.R32FLOATX8X24TYPELESS:
+                case DXGIFormat.X32TYPELESSG8X24UINT:
+                case DXGIFormat.Y416:
+                case DXGIFormat.Y210:
+                case DXGIFormat.Y216:
+                    return 64;
+
+                case DXGIFormat.R10G10B10A2TYPELESS:
+                case DXGIFormat.R10G10B10A2UNORM:
+                case DXGIFormat.R10G10B10A2UINT:
+                case DXGIFormat.R11G11B10FLOAT:
+                case DXGIFormat.R8G8B8A8TYPELESS:
+                case DXGIFormat.R8G8B8A8UNORM:
+                case DXGIFormat.R8G8B8A8UNORMSRGB:
+                case DXGIFormat.R8G8B8A8UINT:
+                case DXGIFormat.R8G8B8A8SNORM:
+                case DXGIFormat.R8G8B8A8SINT:
+                case DXGIFormat.R16G16TYPELESS:
+                case DXGIFormat.R16G16FLOAT:
+                case DXGIFormat.R16G16UNORM:
+                case DXGIFormat.R16G16UINT:
+                case DXGIFormat.R16G16SNORM:
+                case DXGIFormat.R16G16SINT:
+                case DXGIFormat.R32TYPELESS:
+                case DXGIFormat.D32FLOAT:
+                case DXGIFormat.R32FLOAT:
+                case DXGIFormat.R32UINT:
+                case DXGIFormat.R32SINT:
+                case DXGIFormat.R24G8TYPELESS:
+                case DXGIFormat.D24UNORMS8UINT:
+                case DXGIFormat.R24UNORMX8TYPELESS:
+                case DXGIFormat.X24TYPELESSG8UINT:
+                case DXGIFormat.R9G9B9E5SHAREDEXP:
+                case DXGIFormat.R8G8B8G8UNORM:
+                case DXGIFormat.G8R8G8B8UNORM:
+                case DXGIFormat.B8G8R8A8UNORM:
+                case DXGIFormat.B8G8R8X8UNORM:
+                case DXGIFormat.R10G10B10XRBIASA2UNORM:
+                case DXGIFormat.B8G8R8A8TYPELESS:
+                case DXGIFormat.B8G8R8A8UNORMSRGB:
+                case DXGIFormat.B8G8R8X8TYPELESS:
+                case DXGIFormat.B8G8R8X8UNORMSRGB:
+                case DXGIFormat.AYUV:
+                case DXGIFormat.Y410:
+                case DXGIFormat.YUY2:
+                    return 32;
+
+                case DXGIFormat.P010:
+                case DXGIFormat.P016:
+                    return 24;
+
+                case DXGIFormat.R8G8TYPELESS:
+                case DXGIFormat.R8G8UNORM:
+                case DXGIFormat.R8G8UINT:
+                case DXGIFormat.R8G8SNORM:
+                case DXGIFormat.R8G8SINT:
+                case DXGIFormat.R16TYPELESS:
+                case DXGIFormat.R16FLOAT:
+                case DXGIFormat.D16UNORM:
+                case DXGIFormat.R16UNORM:
+                case DXGIFormat.R16UINT:
+                case DXGIFormat.R16SNORM:
+                case DXGIFormat.R16SINT:
+                case DXGIFormat.B5G6R5UNORM:
+                case DXGIFormat.B5G5R5A1UNORM:
+                case DXGIFormat.A8P8:
+                case DXGIFormat.B4G4R4A4UNORM:
+                case DXGIFormat.A4B4G4R4UNORM:
+                    return 16;
+
+                case DXGIFormat.NV12:
+                case DXGIFormat.OPAQUE420:
+                case DXGIFormat.NV11:
+                    return 12;
+
+                case DXGIFormat.R8TYPELESS:
+                case DXGIFormat.R8UNORM:
+                case DXGIFormat.R8UINT:
+                case DXGIFormat.R8SNORM:
+                case DXGIFormat.R8SINT:
+                case DXGIFormat.A8UNORM:
+                case DXGIFormat.BC2TYPELESS:
+                case DXGIFormat.BC2UNORM:
+                case DXGIFormat.BC2UNORMSRGB:
+                case DXGIFormat.BC3TYPELESS:
+                case DXGIFormat.BC3UNORM:
+                case DXGIFormat.BC3UNORMSRGB:
+                case DXGIFormat.BC5TYPELESS:
+                case DXGIFormat.BC5UNORM:
+                case DXGIFormat.BC5SNORM:
+                case DXGIFormat.BC6HTYPELESS:
+                case DXGIFormat.BC6HUF16:
+                case DXGIFormat.BC6HSF16:
+                case DXGIFormat.BC7TYPELESS:
+                case DXGIFormat.BC7UNORM:
+                case DXGIFormat.BC7UNORMSRGB:
+                case DXGIFormat.AI44:
+                case DXGIFormat.IA44:
+                case DXGIFormat.P8:
+                    return 8;
+
+                case DXGIFormat.R1UNORM:
+                    return 1;
+
+                case DXGIFormat.BC1TYPELESS:
+                case DXGIFormat.BC1UNORM:
+                case DXGIFormat.BC1UNORMSRGB:
+                case DXGIFormat.BC4TYPELESS:
+                case DXGIFormat.BC4UNORM:
+                case DXGIFormat.BC4SNORM:
+                    return 4;
+
+                default:
+                    return 0;
+            }
+        }
+
+        /// <summary>
+        /// Based on DirectXTex
+        /// </summary>
+        public static bool IsPixelFormatCompressed(DXGIFormat pixelFormat)
+        {
+            switch (pixelFormat)
+            {
+                case DXGIFormat.BC1TYPELESS:
+                case DXGIFormat.BC1UNORM:
+                case DXGIFormat.BC1UNORMSRGB:
+                case DXGIFormat.BC2TYPELESS:
+                case DXGIFormat.BC2UNORM:
+                case DXGIFormat.BC2UNORMSRGB:
+                case DXGIFormat.BC3TYPELESS:
+                case DXGIFormat.BC3UNORM:
+                case DXGIFormat.BC3UNORMSRGB:
+                case DXGIFormat.BC4TYPELESS:
+                case DXGIFormat.BC4UNORM:
+                case DXGIFormat.BC4SNORM:
+                case DXGIFormat.BC5TYPELESS:
+                case DXGIFormat.BC5UNORM:
+                case DXGIFormat.BC5SNORM:
+                case DXGIFormat.BC6HTYPELESS:
+                case DXGIFormat.BC6HUF16:
+                case DXGIFormat.BC6HSF16:
+                case DXGIFormat.BC7TYPELESS:
+                case DXGIFormat.BC7UNORM:
+                case DXGIFormat.BC7UNORMSRGB:
+                    return true;
+                default:
+                    return false;
+            }
+        }
 
         /// <summary>
         /// RawTex Switch Texture Info
@@ -167,14 +226,15 @@ namespace DrSwizzler
               31
         };
 
+        
+
         /// <summary>
         /// Based on RawTex handling
         /// </summary>
         public static void GetsourceBytesPerPixelSetAndPixelSize(DXGIFormat pixelFormat, out int sourceBytesPerPixelSet, out int pixelBlockSize, out int formatBpp)
         {
-            int pixelFormatInt = (int)pixelFormat;
             //The amount of pixels chunked together in a particular 'block'. Formats such as the DXT formats lump multiple pixels into one 'block' and must be handled as such.
-            if ((pixelFormatInt >= 70 && pixelFormatInt <= 84) || (pixelFormatInt >= 94 && pixelFormatInt <= 99))
+            if (IsPixelFormatCompressed(pixelFormat))
             {
                 pixelBlockSize = 4;
             }
@@ -183,7 +243,7 @@ namespace DrSwizzler
                 pixelBlockSize = 1;
             }
 
-            formatBpp = bitsPerPixel[pixelFormatInt];
+            formatBpp = BitsPerPixel(pixelFormat);
             if (pixelBlockSize == 1)
             {
                 sourceBytesPerPixelSet = formatBpp / 8;


### PR DESCRIPTION
- I added more Xbox 360 formats according UEViewer, such as G8 (A8/R8) and V8U8 (R8G8), because I had encountered some textures which were in A8 format.

- I also added their various data types forms (Unorm, Snorm, sRGB, Typeless, etc.) to make it more flexible. (I also had encountered sRGB textures).

- I removed BC4 and BC5, because they are not aligned, according to UEViewer.

- I added some helper functions such as BitsPerPixel and IsPixelFormatCompressed for better readability, and an additional DXGI enum for A4B4G4R4.

With your permission, I can start making some of the code more readable, which may require some refactoring. I might add unit tests and some of the stuff discussed in #1.